### PR TITLE
Fix date util and safe navigation

### DIFF
--- a/src/components/shared/service-card.tsx
+++ b/src/components/shared/service-card.tsx
@@ -18,11 +18,11 @@ export function ServiceCard({
   subtitle,
   rating,
   id,
-}: ServiceCardProps) {
-  const router = useRouter();
-  return (
-    <TouchableOpacity
-      onPress={() => router.push(`/professional/${id}`)}
+  }: ServiceCardProps) {
+    const router = useRouter();
+    return (
+      <TouchableOpacity
+        onPress={() => id && router.push(`/professional/${id}`)}
       className="w-[180px] aspect-[3/4] bg-popover border border-ring/10 relative overflow-hidden rounded-xl mr-4"
     >
       <Image

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 
 const isValidDate = (date: string | null) =>
-  !date || date === undefined || date !== typeof 'string';
+  !date || typeof date !== 'string';
 
 export const getLocalizedWeeks = () => {
   const current = new Date().getFullYear();


### PR DESCRIPTION
## Summary
- correct validation logic for dates
- guard navigation when service ID is missing

## Testing
- `npx tsc --noEmit` *(fails: cannot find module 'expo-status-bar' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684a4a055d50833085023d67b9942c76